### PR TITLE
Update to version 2.0.1-beta.36

### DIFF
--- a/Formula/azure-functions-core-tools.rb
+++ b/Formula/azure-functions-core-tools.rb
@@ -1,10 +1,10 @@
 class AzureFunctionsCoreTools < Formula
   desc "Azure Function Cli 2.0"
   homepage "https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local#run-azure-functions-core-tools"
-  url "https://functionscdn.azureedge.net/public/2.0.1-beta.35/Azure.Functions.Cli.osx-x64.2.0.1-beta.35.zip"
-  version "2.0.1-beta.35"
+  url "https://functionscdn.azureedge.net/public/2.0.1-beta.36/Azure.Functions.Cli.osx-x64.2.0.1-beta.36.zip"
+  version "2.0.1-beta.36"
   # make sure sha256 is lowercase.
-  sha256 "ce13db69e7635808e0d2573b920f42ff0e61dc2ade61315856cd3a403272055e"
+  sha256 "409ef4971241971bb3c7157f82b468506632957364adc709f7c59a01e49aef2b"
   head "https://github.com/Azure/azure-functions-core-tools"
 
   bottle :unneeded


### PR DESCRIPTION
Updating formula to version 2.0.1-beta.36

https://github.com/Azure/azure-functions-core-tools/releases/tag/2.0.1-beta.36

Hash was retrieved from:

https://github.com/Azure/azure-functions-core-tools/releases/download/2.0.1-beta.36/Azure.Functions.Cli.osx-x64.2.0.1-beta.36.zip.sha2

