### PR TITLE
Add exec permissions to gozip

### DIFF
--- a/Formula/azure-functions-core-tools-v3-preview.rb
+++ b/Formula/azure-functions-core-tools-v3-preview.rb
@@ -16,6 +16,7 @@ class AzureFunctionsCoreToolsV3Preview < Formula
   def install
     prefix.install Dir["*"]
     chmod 0555, prefix/"func"
+    chmod 0555, prefix/"gozip"
     bin.install_symlink prefix/"func"
     begin
       FileUtils.touch(prefix/"telemetryDefaultOn.sentinel")

--- a/Formula/azure-functions-core-tools.rb
+++ b/Formula/azure-functions-core-tools.rb
@@ -16,6 +16,7 @@ class AzureFunctionsCoreTools < Formula
   def install
     prefix.install Dir["*"]
     chmod 0555, prefix/"func"
+    chmod 0555, prefix/"gozip"
     bin.install_symlink prefix/"func"
     begin
       FileUtils.touch(prefix/"telemetryDefaultOn.sentinel")

--- a/Formula/azure-functions-core-tools@3.rb
+++ b/Formula/azure-functions-core-tools@3.rb
@@ -16,6 +16,7 @@ class AzureFunctionsCoreToolsAT3 < Formula
   def install
     prefix.install Dir["*"]
     chmod 0555, prefix/"func"
+    chmod 0555, prefix/"gozip"
     bin.install_symlink prefix/"func"
     begin
       FileUtils.touch(prefix/"telemetryDefaultOn.sentinel")


### PR DESCRIPTION
Need to do this for v3 as well.

Although, first need to make sure that gozip is merged in v3 too.