### PR TITLE
Remove chmod gozip, as core-tools isn't up to date

### DIFF
--- a/Formula/azure-functions-core-tools-v3-preview.rb
+++ b/Formula/azure-functions-core-tools-v3-preview.rb
@@ -16,7 +16,6 @@ class AzureFunctionsCoreToolsV3Preview < Formula
   def install
     prefix.install Dir["*"]
     chmod 0555, prefix/"func"
-    chmod 0555, prefix/"gozip"
     bin.install_symlink prefix/"func"
     begin
       FileUtils.touch(prefix/"telemetryDefaultOn.sentinel")

--- a/Formula/azure-functions-core-tools.rb
+++ b/Formula/azure-functions-core-tools.rb
@@ -16,7 +16,6 @@ class AzureFunctionsCoreTools < Formula
   def install
     prefix.install Dir["*"]
     chmod 0555, prefix/"func"
-    chmod 0555, prefix/"gozip"
     bin.install_symlink prefix/"func"
     begin
       FileUtils.touch(prefix/"telemetryDefaultOn.sentinel")

--- a/Formula/azure-functions-core-tools@3.rb
+++ b/Formula/azure-functions-core-tools@3.rb
@@ -16,7 +16,6 @@ class AzureFunctionsCoreToolsAT3 < Formula
   def install
     prefix.install Dir["*"]
     chmod 0555, prefix/"func"
-    chmod 0555, prefix/"gozip"
     bin.install_symlink prefix/"func"
     begin
       FileUtils.touch(prefix/"telemetryDefaultOn.sentinel")


### PR DESCRIPTION
I forgot that homebrew Formula update means it is live.
We haven't release core-tools with gozip. This would result in an error. Removing this for now. Will add a "safe" chmod later.