### PR TITLE
Remove deprecated 'bottle :unneeded'

### DIFF
--- a/Formula/azure-functions-core-tools-v3-preview.rb
+++ b/Formula/azure-functions-core-tools-v3-preview.rb
@@ -7,7 +7,6 @@ class AzureFunctionsCoreToolsV3Preview < Formula
   sha256 "857b3546b2a336e5e7bac4012cb6a9ea141f910030c58f0ce8e21784553aa527"
   head "https://github.com/Azure/azure-functions-core-tools"
 
-  bottle :unneeded
 
   @@telemetry = "\n Telemetry \n --------- \n The Azure Functions Core tools collect usage data in order to help us improve your experience." \
   + "\n The data is anonymous and doesn\'t include any user specific or personal information. The data is collected by Microsoft." \

--- a/Formula/azure-functions-core-tools.rb
+++ b/Formula/azure-functions-core-tools.rb
@@ -7,7 +7,6 @@ class AzureFunctionsCoreTools < Formula
   sha256 "baa850c449e9be5fcef8e2bf91883885ec9ab9471437c998701435f5164d72e5"
   head "https://github.com/Azure/azure-functions-core-tools"
 
-  bottle :unneeded
 
   @@telemetry = "\n Telemetry \n --------- \n The Azure Functions Core tools collect usage data in order to help us improve your experience." \
   + "\n The data is anonymous and doesn\'t include any user specific or personal information. The data is collected by Microsoft." \

--- a/Formula/azure-functions-core-tools@2.rb
+++ b/Formula/azure-functions-core-tools@2.rb
@@ -7,7 +7,6 @@ class AzureFunctionsCoreToolsAT2 < Formula
   sha256 "baa850c449e9be5fcef8e2bf91883885ec9ab9471437c998701435f5164d72e5"
   head "https://github.com/Azure/azure-functions-core-tools"
 
-  bottle :unneeded
 
   @@telemetry = "\n Telemetry \n --------- \n The Azure Functions Core tools collect usage data in order to help us improve your experience." \
   + "\n The data is anonymous and doesn\'t include any user specific or personal information. The data is collected by Microsoft." \

--- a/Formula/azure-functions-core-tools@3.rb
+++ b/Formula/azure-functions-core-tools@3.rb
@@ -7,7 +7,6 @@ class AzureFunctionsCoreToolsAT3 < Formula
   sha256 "857b3546b2a336e5e7bac4012cb6a9ea141f910030c58f0ce8e21784553aa527"
   head "https://github.com/Azure/azure-functions-core-tools"
 
-  bottle :unneeded
 
   @@telemetry = "\n Telemetry \n --------- \n The Azure Functions Core tools collect usage data in order to help us improve your experience." \
   + "\n The data is anonymous and doesn\'t include any user specific or personal information. The data is collected by Microsoft." \

--- a/Formula/azure-functions-core-tools@4.rb
+++ b/Formula/azure-functions-core-tools@4.rb
@@ -7,7 +7,6 @@ class AzureFunctionsCoreToolsAT4 < Formula
   sha256 "f15d785d6d6ada9dad19dc07d23f6b44ab4fb456e449567a16efe726778c830a"
   head "https://github.com/Azure/azure-functions-core-tools"
 
-  bottle :unneeded
 
   @@telemetry = "\n Telemetry \n --------- \n The Azure Functions Core tools collect usage data in order to help us improve your experience." \
   + "\n The data is anonymous and doesn\'t include any user specific or personal information. The data is collected by Microsoft." \


### PR DESCRIPTION
Fixes https://github.com/Azure/homebrew-functions/issues/89

Formula parameter `bottle :unneeded` has been deprecated.

https://github.com/Homebrew/brew/commit/f65d525
https://github.com/Homebrew/brew/pull/11239