### PR TITLE
Add support for Linux

### DIFF
--- a/Formula/azure-functions-core-tools-v3-preview.rb
+++ b/Formula/azure-functions-core-tools-v3-preview.rb
@@ -1,12 +1,19 @@
 class AzureFunctionsCoreToolsV3Preview < Formula
-  desc "Azure Functions Core Tools 3.0"
-  homepage "https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local#run-azure-functions-core-tools"
-  url "https://functionscdn.azureedge.net/public/3.0.3904/Azure.Functions.Cli.osx-x64.3.0.3904.zip"
-  version "3.0.3904"
-  # make sure sha256 is lowercase.
-  sha256 "fc3cc4a4a2d70220fb64bee4bc9b69adbcfb87e80392b5761f7647bf7afea5ab"
-  head "https://github.com/Azure/azure-functions-core-tools"
+  funcVersion = "3.0.3904"
+  if OS.linux?
+    funcArch = "linux-x64"
+    funcSha = "2fda421ef6761acf9f12ef70735cf241774c8351bd83889366d01ce9ce1605ff"
+  else
+    funcArch = "osx-x64"
+    funcSha = "fc3cc4a4a2d70220fb64bee4bc9b69adbcfb87e80392b5761f7647bf7afea5ab"
+  end
 
+  desc "Azure Functions Core Tools 3.0"
+  homepage "https://docs.microsoft.com/azure/azure-functions/functions-run-local#run-azure-functions-core-tools"
+  url "https://functionscdn.azureedge.net/public/#{funcVersion}/Azure.Functions.Cli.#{funcArch}.#{funcVersion}.zip"
+  sha256 funcSha
+  version funcVersion
+  head "https://github.com/Azure/azure-functions-core-tools"
 
   @@telemetry = "\n Telemetry \n --------- \n The Azure Functions Core tools collect usage data in order to help us improve your experience." \
   + "\n The data is anonymous and doesn\'t include any user specific or personal information. The data is collected by Microsoft." \

--- a/Formula/azure-functions-core-tools.rb
+++ b/Formula/azure-functions-core-tools.rb
@@ -1,12 +1,19 @@
 class AzureFunctionsCoreTools < Formula
-  desc "Azure Functions Core Tools 2.0"
-  homepage "https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local#run-azure-functions-core-tools"
-  url "https://functionscdn.azureedge.net/public/2.7.3188/Azure.Functions.Cli.osx-x64.2.7.3188.zip"
-  version "2.7.3188"
-  # make sure sha256 is lowercase.
-  sha256 "baa850c449e9be5fcef8e2bf91883885ec9ab9471437c998701435f5164d72e5"
-  head "https://github.com/Azure/azure-functions-core-tools"
+  funcVersion = "2.7.3188"
+  if OS.linux?
+    funcArch = "linux-x64"
+    funcSha = "f8cff611d0cc2198589a7ff0b1b268549bf86c11afd799098df59f7721d6b771"
+  else
+    funcArch = "osx-x64"
+    funcSha = "baa850c449e9be5fcef8e2bf91883885ec9ab9471437c998701435f5164d72e5"
+  end
 
+  desc "Azure Functions Core Tools 2.0"
+  homepage "https://docs.microsoft.com/azure/azure-functions/functions-run-local#run-azure-functions-core-tools"
+  url "https://functionscdn.azureedge.net/public/#{funcVersion}/Azure.Functions.Cli.#{funcArch}.#{funcVersion}.zip"
+  sha256 funcSha
+  version funcVersion
+  head "https://github.com/Azure/azure-functions-core-tools"
 
   @@telemetry = "\n Telemetry \n --------- \n The Azure Functions Core tools collect usage data in order to help us improve your experience." \
   + "\n The data is anonymous and doesn\'t include any user specific or personal information. The data is collected by Microsoft." \

--- a/Formula/azure-functions-core-tools@2.rb
+++ b/Formula/azure-functions-core-tools@2.rb
@@ -1,12 +1,19 @@
 class AzureFunctionsCoreToolsAT2 < Formula
-  desc "Azure Functions Core Tools 2.0"
-  homepage "https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local#run-azure-functions-core-tools"
-  url "https://functionscdn.azureedge.net/public/2.7.3188/Azure.Functions.Cli.osx-x64.2.7.3188.zip"
-  version "2.7.3188"
-  # make sure sha256 is lowercase.
-  sha256 "baa850c449e9be5fcef8e2bf91883885ec9ab9471437c998701435f5164d72e5"
-  head "https://github.com/Azure/azure-functions-core-tools"
+  funcVersion = "2.7.3188"
+  if OS.linux?
+    funcArch = "linux-x64"
+    funcSha = "f8cff611d0cc2198589a7ff0b1b268549bf86c11afd799098df59f7721d6b771"
+  else
+    funcArch = "osx-x64"
+    funcSha = "baa850c449e9be5fcef8e2bf91883885ec9ab9471437c998701435f5164d72e5"
+  end
 
+  desc "Azure Functions Core Tools 2.0"
+  homepage "https://docs.microsoft.com/azure/azure-functions/functions-run-local#run-azure-functions-core-tools"
+  url "https://functionscdn.azureedge.net/public/#{funcVersion}/Azure.Functions.Cli.#{funcArch}.#{funcVersion}.zip"
+  sha256 funcSha
+  version funcVersion
+  head "https://github.com/Azure/azure-functions-core-tools"
 
   @@telemetry = "\n Telemetry \n --------- \n The Azure Functions Core tools collect usage data in order to help us improve your experience." \
   + "\n The data is anonymous and doesn\'t include any user specific or personal information. The data is collected by Microsoft." \

--- a/Formula/azure-functions-core-tools@3.rb
+++ b/Formula/azure-functions-core-tools@3.rb
@@ -1,12 +1,19 @@
 class AzureFunctionsCoreToolsAT3 < Formula
-  desc "Azure Functions Core Tools 3.0"
-  homepage "https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local#run-azure-functions-core-tools"
-  url "https://functionscdn.azureedge.net/public/3.0.3904/Azure.Functions.Cli.osx-x64.3.0.3904.zip"
-  version "3.0.3904"
-  # make sure sha256 is lowercase.
-  sha256 "fc3cc4a4a2d70220fb64bee4bc9b69adbcfb87e80392b5761f7647bf7afea5ab"
-  head "https://github.com/Azure/azure-functions-core-tools"
+  funcVersion = "3.0.3904"
+  if OS.linux?
+    funcArch = "linux-x64"
+    funcSha = "2fda421ef6761acf9f12ef70735cf241774c8351bd83889366d01ce9ce1605ff"
+  else
+    funcArch = "osx-x64"
+    funcSha = "fc3cc4a4a2d70220fb64bee4bc9b69adbcfb87e80392b5761f7647bf7afea5ab"
+  end
 
+  desc "Azure Functions Core Tools 3.0"
+  homepage "https://docs.microsoft.com/azure/azure-functions/functions-run-local#run-azure-functions-core-tools"
+  url "https://functionscdn.azureedge.net/public/#{funcVersion}/Azure.Functions.Cli.#{funcArch}.#{funcVersion}.zip"
+  sha256 funcSha
+  version funcVersion
+  head "https://github.com/Azure/azure-functions-core-tools"
 
   @@telemetry = "\n Telemetry \n --------- \n The Azure Functions Core tools collect usage data in order to help us improve your experience." \
   + "\n The data is anonymous and doesn\'t include any user specific or personal information. The data is collected by Microsoft." \

--- a/Formula/azure-functions-core-tools@4.rb
+++ b/Formula/azure-functions-core-tools@4.rb
@@ -1,10 +1,18 @@
 class AzureFunctionsCoreToolsAT4 < Formula
+  funcVersion = "4.0.3971"
+  if OS.linux?
+    funcArch = "linux-x64"
+    funcSha = "a3b606182b001d88239e4669a30f09b70aebf8747d10c780d2bff457e0bf7997"
+  else
+    funcArch = "osx-x64"
+    funcSha = "9a852a5c5e28ea043e8c141e6e690c8535a4cc1996018ef25d902b1704914fdd"
+  end
+
   desc "Azure Functions Core Tools 4.0"
-  homepage "https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local#run-azure-functions-core-tools"
-  url "https://functionscdn.azureedge.net/public/4.0.3971/Azure.Functions.Cli.osx-x64.4.0.3971.zip"
-  version "4.0.3971"
-  # make sure sha256 is lowercase.
-  sha256 "9a852a5c5e28ea043e8c141e6e690c8535a4cc1996018ef25d902b1704914fdd"
+  homepage "https://docs.microsoft.com/azure/azure-functions/functions-run-local#run-azure-functions-core-tools"
+  url "https://functionscdn.azureedge.net/public/#{funcVersion}/Azure.Functions.Cli.#{funcArch}.#{funcVersion}.zip"
+  sha256 funcSha
+  version funcVersion
   head "https://github.com/Azure/azure-functions-core-tools"
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,57 @@
+pr:
+  branches:
+    include:
+      - master
+
+trigger:
+- master
+
+jobs:
+- job: Test
+  strategy:
+    matrix:
+      Mac_v4:
+        ImageType: 'macOS-latest'
+        FileSuffix: '@4'
+        MajorVersion: '4'
+      Mac_v3:
+        ImageType: 'macOS-latest'
+        FileSuffix: '@3'
+        MajorVersion: '3'
+      Mac_v3_legacy:
+        ImageType: 'macOS-latest'
+        FileSuffix: '-v3-preview'
+        MajorVersion: '3'
+      Mac_v2:
+        ImageType: 'macOS-latest'
+        FileSuffix: '@2'
+        MajorVersion: '2'
+      Mac_v2_legacy:
+        ImageType: 'macOS-latest'
+        FileSuffix: ''
+        MajorVersion: '2'
+      Linux_v4:
+        ImageType: 'ubuntu-latest'
+        FileSuffix: '@4'
+        MajorVersion: '4'
+      Linux_v3:
+        ImageType: 'ubuntu-latest'
+        FileSuffix: '@3'
+        MajorVersion: '3'
+      Linux_v3_legacy:
+        ImageType: 'ubuntu-latest'
+        FileSuffix: '-v3-preview'
+        MajorVersion: '3'
+      Linux_v2:
+        ImageType: 'ubuntu-latest'
+        FileSuffix: '@2'
+        MajorVersion: '2'
+      Linux_v2_legacy:
+        ImageType: 'ubuntu-latest'
+        FileSuffix: ''
+        MajorVersion: '2'
+  pool:
+    vmImage: $(ImageType)
+  steps:
+  - pwsh: ./test.ps1 -MajorVersion "$(MajorVersion)" -FileSuffix "$(FileSuffix)"
+    displayName: 'Test brew formula'

--- a/test.ps1
+++ b/test.ps1
@@ -1,0 +1,28 @@
+param (
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $MajorVersion,
+
+    [Parameter(Mandatory=$true)]
+    [AllowEmptyString()]
+    [string]
+    $FileSuffix
+)
+
+brew tap azure/functions
+if (-not $?) { exit 1 }
+
+brew install "./Formula/azure-functions-core-tools$FileSuffix.rb"
+if (-not $?) { exit 1 }
+
+$funcOutput = func --version
+if (-not $?) { exit 1 }
+
+$actualMajorVersion = ([version]$funcOutput.trim()).Major
+if ($actualMajorVersion -ne $MajorVersion) {
+    Write-Error "Expected: ""$MajorVersion"", Actual ""$actualMajorVersion"""
+    exit 1
+} else {
+    Write-Output "func installed and version matched! 🎉"
+}

--- a/update.ps1
+++ b/update.ps1
@@ -1,0 +1,64 @@
+param (
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $dropLocation
+)
+
+$files= Get-ChildItem -Recurse -Path "$dropLocation"
+
+foreach($file in $files)
+{
+    if ($file.FullName -match '\.([0-9]+\.[0-9]+\.[0-9]+)\.zip$')
+    {
+        $version = $Matches.1
+        Write-Host "New func version: ""$version"""
+        break
+    }
+}
+
+if (-Not $version) {
+    throw "Failed to determine new func version from drop ""$dropLocation"""
+}
+
+function updateFormula([string]$fileSuffix) {
+    $filePath = "./Formula/azure-functions-core-tools$fileSuffix.rb"
+    $content = Get-Content $filePath -Raw
+
+    # Update version
+    if ($content -match 'funcVersion = "(.*)"') {
+        $oldVersion = $Matches.1
+        $content = $content.Replace($oldVersion, $version)
+    } else {
+        throw "Failed to find funcVersion entry in ""$filePath"""
+    }
+
+    # Update sha for each arch
+    foreach($arch in "osx-x64", "linux-x64") {
+        if ($content -match "funcArch = ""$arch""\s*funcSha = ""(.*)""") {
+            $oldSha = $Matches.1
+            $shaPath = Join-Path $dropLocation "Azure.Functions.Cli.$arch.$version.zip.sha2"
+            $sha = Get-Content -Path $shaPath
+            $content = $content.Replace($oldSha, $sha)
+        } else {
+            Write-Host "Skipping arch ""$arch"", not found in ""$filePath"""
+        }
+    }
+
+    Set-Content -Path $filePath -Value $content -NoNewline
+    Write-Host "Updated formula $filePath"
+}
+
+$majorVersion=([version]$version).Major
+
+updateFormula "@$majorVersion"
+
+# Also update files with legacy suffixes
+if($majorVersion -eq "2")
+{
+    updateFormula ""
+}
+elseif($majorVersion -eq "3")
+{
+    updateFormula "-v3-preview"
+}


### PR DESCRIPTION
Fixes https://github.com/Azure/homebrew-functions/issues/95

This work is also relevant to Mac arm64 support, which will be coming soon.

In order to help verify my changes I also added the following:
- Dev Ops build that installs the local formula, runs `func --version`, and verifies the major version is as expected. Not the most complex test, but way better than nothing
- Script to update the formula based on a drop location. We already had a script in our core tools release pipeline, but I had to make a lot of changes to support multiple arches. I prefer putting most of the script directly in this repo because it's much easier to test locally and has better history. I plan to update the release pipeline script to reference this script (the release pipeline script still handles stuff like creating/submitting a PR)