### PR TITLE
Add support for arm

### DIFF
--- a/Formula/azure-functions-core-tools@4.rb
+++ b/Formula/azure-functions-core-tools@4.rb
@@ -3,6 +3,9 @@ class AzureFunctionsCoreToolsAT4 < Formula
   if OS.linux?
     funcArch = "linux-x64"
     funcSha = "988f35286c16b9d9ac8bad778707b7d2bd63d0c179bea0092c9e25b1b1193b50"
+  elsif Hardware::CPU.arm?
+    funcArch = "osx-arm64"
+    funcSha = "6463403157f9db06075225e60960e31819448f0dbcdb6056770bd4b7ac608ee7"
   else
     funcArch = "osx-x64"
     funcSha = "392d95aba87576790655da023f5975bb582422505fcb0b1196f57db069d1bed5"

--- a/update.ps1
+++ b/update.ps1
@@ -34,7 +34,7 @@ function updateFormula([string]$fileSuffix) {
     }
 
     # Update sha for each arch
-    foreach($arch in "osx-x64", "linux-x64") {
+    foreach($arch in "osx-x64", "osx-arm64", "linux-x64") {
         if ($content -match "funcArch = ""$arch""\s*funcSha = ""(.*)""") {
             $oldSha = $Matches.1
             $shaPath = Join-Path $dropLocation "Azure.Functions.Cli.$arch.$version.zip.sha2"


### PR DESCRIPTION
The plan is to wait to merge this until we're ready to do a v4 release with signed binaries. If we don't sign the binaries, any command you run will just silently fail
- A comment about it [here](https://github.com/Azure/azure-functions-core-tools/issues/2834#issuecomment-1102927470)
- A blog post about how Apple requires arm64 executables to be signed [here](https://eclecticlight.co/2020/08/22/apple-silicon-macs-will-require-signed-code/)
- My PR that was recently merged here and will be included in the next release [here](https://github.com/Azure/azure-functions-core-tools/pull/3033)