### PR TITLE
Add brew to path on Linux build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
   pool:
     vmImage: $(ImageType)
   steps:
-  - script: PATH="/home/linuxbrew/.linuxbrew/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+  - script: echo "##vso[task.prependpath]/home/linuxbrew/.linuxbrew/bin:/opt/homebrew/bin:/usr/local/bin"
     displayName: 'Add brew to path'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
   - pwsh: ./test.ps1 -MajorVersion "$(MajorVersion)" -FileSuffix "$(FileSuffix)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,5 +53,8 @@ jobs:
   pool:
     vmImage: $(ImageType)
   steps:
+  - script: PATH="/home/linuxbrew/.linuxbrew/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+    displayName: 'Add brew to path'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
   - pwsh: ./test.ps1 -MajorVersion "$(MajorVersion)" -FileSuffix "$(FileSuffix)"
     displayName: 'Test brew formula'


### PR DESCRIPTION
They removed brew from the path variable on Linux for some weird reason which broke our builds: https://github.com/actions/runner-images/issues/6283

And the suggested fix is to add the path back ourselves

NOTE: I copied the path from the "Setup homebrew" Github action instead of the path mentioned in the issue - no particular reason though and it worked 🤷‍♂️. https://github.com/Homebrew/actions/blob/master/setup-homebrew/main.sh#L34