### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ```bash
 brew tap azure/functions
-brew install azure-functions-core-tools
+brew install azure-functions-core-tools@4
 ```
 
 # Contributing


### PR DESCRIPTION
The default version is 2.x which gives you a warning message `You are using an outdated version of the Azure Functions Core Tools.` 
This PR is only a quick fix. The long-term solution is proposed in #127.