### PR TITLE
Dynamically update dropLocation

### DIFF
--- a/update.ps1
+++ b/update.ps1
@@ -1,7 +1,7 @@
 param (
     [Parameter(Mandatory=$true)]
     [ValidateNotNullOrEmpty()]
-    [string] $dropLocation,
+    [string] $artifactsDirectoryRoot,
 
     [Parameter(Mandatory=$true)]
     [ValidateNotNullOrEmpty()]
@@ -36,6 +36,7 @@ function updateFormula([string]$fileSuffix) {
     foreach($arch in "osx-x64", "osx-arm64", "linux-x64") {
         if ($content -match "funcArch = ""$arch""\s*funcSha = ""(.*)""") {
             $oldSha = $Matches.1
+            $dropLocation = "$artifactsDirectoryRoot/_core-tools-consolidated-artifacts.official/drop-$arch/coretools-cli"
             $shaPath = Join-Path $dropLocation "Azure.Functions.Cli.$arch.$version.zip.sha2"
             $sha = Get-Content -Path $shaPath
             $content = $content.Replace($oldSha, $sha)


### PR DESCRIPTION
Our old script for releasing to Homebrew stopped working because the location of our artifacts changed. They now need to be set dynamically depending on the architecture of the artifact (for example, osx-x64 is in a different folder from osx-arm64).

This PR dynamically sets the location for these artifacts. All that the caller needs to provide now is `$(System.ArtifactsDirectory)` as the `$artifactsDirectoryRoot`.